### PR TITLE
Clean up after installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-latest
-    
+
     steps:
       - uses: actions/checkout@v3
 
@@ -28,3 +28,8 @@ jobs:
         shell: bash
         run: |
           which doxygen
+
+      - name: Check cleanup
+        shell: bash
+        run: |
+          ! ls doxygen* 1> /dev/null 2>&1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,4 @@ jobs:
         shell: bash
         run: |
           ! ls doxygen* 1> /dev/null 2>&1
+          ! ls Doxygen* 1> /dev/null 2>&1

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,8 @@ runs:
         tar xzvf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
         cd doxygen-${DOXYGEN_VERSION}
         sudo make install
+        cd ..
+        rm -rf doxygen-${DOXYGEN_VERSION}* # Clean up
     
     - name: "Windows installation"
       if: runner.os == 'Windows'
@@ -31,6 +33,8 @@ runs:
         curl -kLSs https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.windows.x64.bin.zip -o doxygen.zip
         unzip doxygen.zip
         cp * c:\\Windows
+        cd ..
+        rm -rf doxygen # Clean up
     
     - name: "MacOS installation"
       if: runner.os == 'MacOS'
@@ -42,3 +46,4 @@ runs:
         sudo cp /Volumes/Doxygen/Doxygen.app/Contents/Resources/doxygen /usr/local/bin
         sudo cp /Volumes/Doxygen/Doxygen.app/Contents/Resources/doxyindexer /usr/local/bin
         sudo hdiutil detach /Volumes/Doxygen
+        rm Doxygen-${DOXYGEN_VERSION}.dmg # Clean up

--- a/action.yml
+++ b/action.yml
@@ -28,13 +28,13 @@ runs:
       if: runner.os == 'Windows'
       shell: bash
       run: |
-        mkdir doxygen
-        cd doxygen
+        mkdir doxygen-${DOXYGEN_VERSION}-windows
+        cd doxygen-${DOXYGEN_VERSION}-windows
         curl -kLSs https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.windows.x64.bin.zip -o doxygen.zip
         unzip doxygen.zip
         cp * c:\\Windows
         cd ..
-        rm -rf doxygen # Clean up
+        rm -rf doxygen-${DOXYGEN_VERSION}-windows # Clean up
     
     - name: "MacOS installation"
       if: runner.os == 'MacOS'


### PR DESCRIPTION
- Remove all the folders used to install Doxygen after its installation, cleaning up the workspace.
- Added a test to ensure that the cleanup was successful.

[ closes #2 ]